### PR TITLE
Fix[#4]: duplicate folder names

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,11 @@ function App() {
       sections: [],
       index: folders.length // Set the index to place the new folder at the end
     }
-    setFolders([...folders, newFolder])
-    setActiveFolder(newFolder.id)
+    const existingFolder = folders.find((folder) => folder.name === name);
+    if (!existingFolder) {
+      setFolders([...folders, newFolder]);
+    }
+    setActiveFolder(existingFolder ? existingFolder.id : newFolder.id);
   }
 
   const handleAddSection = (folderId: string, name: string) => {


### PR DESCRIPTION
When a user tries to create a new folder, it checks if the a folder with that name already exists if so it ignores creating it and passes to selecting it otherwise it creates it then select it